### PR TITLE
Allow TemplateFinders to look for multiple extensions (against dev)

### DIFF
--- a/src/Finder/FoldersTemplateFinder.php
+++ b/src/Finder/FoldersTemplateFinder.php
@@ -13,9 +13,10 @@ namespace Brain\Hierarchy\Finder;
 use ArrayIterator;
 
 /**
- * Very similar the way WordPress core works, however, it allows to search templates arbitrary
- * folders and to use a custom file extension (default to php). By default, stylesheet and template
- * folders and file extension to php, so it acts exactly like core.
+ * Very similar to the way WordPress core works, however, it allows to search
+ * templates within arbitrary folders and to use one or more custom file
+ * extensions. By default, it looks through stylesheet and template folders and
+ * allows file extension to be php, so it acts exactly like core.
  *
  * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
  * @license http://opensource.org/licenses/MIT MIT
@@ -31,13 +32,13 @@ final class FoldersTemplateFinder implements TemplateFinderInterface
     private $folders;
 
     /**
-     * @var string
+     * @var string|array
      */
-    private $extension;
+    private $extensions;
 
     /**
-     * @param array  $folders
-     * @param string $extension
+     * @param array        $folders
+     * @param string|array $extension
      */
     public function __construct(array $folders = [], $extension = 'php')
     {
@@ -49,7 +50,9 @@ final class FoldersTemplateFinder implements TemplateFinderInterface
         }
 
         $this->folders = array_map('trailingslashit', $folders);
-        $this->extension = $extension;
+        $this->extensions = array_unique(
+            array_filter((array) $extension, 'is_string')
+        );
     }
 
     /**
@@ -58,8 +61,14 @@ final class FoldersTemplateFinder implements TemplateFinderInterface
     public function find($template, $type)
     {
         foreach ($this->folders as $folder) {
-            if (file_exists($folder.$template.'.'.$this->extension)) {
-                return $folder.$template.'.'.$this->extension;
+            $path = $folder.$template;
+            foreach ($this->extensions as $extension) {
+                if ('' !== $extension) {
+                    $extension = '.'.$extension;
+                }
+                if (file_exists($path.$extension)) {
+                    return $path.$extension;
+                }
             }
         }
 

--- a/src/Finder/SubfolderTemplateFinder.php
+++ b/src/Finder/SubfolderTemplateFinder.php
@@ -11,8 +11,9 @@
 namespace Brain\Hierarchy\Finder;
 
 /**
- * Very similar the way WordPress core works, however, it allows to search templates in a subfolder
- * (for both parent and child themes) and to use a custom file extension (default to php).
+ * Very similar to the way WordPress core works, however, it allows to search
+ * templates in a subfolder (for both parent and child themes) and to use one or
+ * more custom file extensions (defaults to php).
  *
  * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
  * @license http://opensource.org/licenses/MIT MIT
@@ -26,8 +27,8 @@ final class SubfolderTemplateFinder implements TemplateFinderInterface
     private $finder;
 
     /**
-     * @param string $subfolder
-     * @param string $extension
+     * @param string       $subfolder
+     * @param string|array $extension
      */
     public function __construct($subfolder, $extension = 'php')
     {

--- a/tests/files/archive
+++ b/tests/files/archive
@@ -1,0 +1,1 @@
+archive

--- a/tests/files/singular.php
+++ b/tests/files/singular.php
@@ -1,0 +1,1 @@
+singular

--- a/tests/src/Unit/Finder/FoldersTemplateFinderTest.php
+++ b/tests/src/Unit/Finder/FoldersTemplateFinderTest.php
@@ -47,4 +47,29 @@ final class FoldersTemplateFinderTest extends TestCase
 
         assertSame($template, $finder->findFirst(['page-foo', 'another', 'index'], 'page'));
     }
+
+    public function testFindSeveralExtensions()
+    {
+        $twigTemplate     = getenv('HIERARCHY_TESTS_BASEPATH').'/files/singular.twig';
+        $phpTemplate      = getenv('HIERARCHY_TESTS_BASEPATH').'/files/singular.php';
+        $fallbackTemplate = getenv('HIERARCHY_TESTS_BASEPATH').'/files/single.php';
+
+        $folders    = [getenv('HIERARCHY_TESTS_BASEPATH').'/files'];
+        $twigFinder = new FoldersTemplateFinder($folders, ['twig', 'php']);
+        $phpFinder  = new FoldersTemplateFinder($folders, ['php', 'twig']);
+
+        assertSame($twigTemplate, $twigFinder->find('singular', 'singular'));
+        assertSame($phpTemplate, $phpFinder->find('singular', 'singular'));
+        assertSame($fallbackTemplate, $twigFinder->find('single', 'single'));
+    }
+
+    public function testFindExtensionless()
+    {
+        $template = getenv('HIERARCHY_TESTS_BASEPATH').'/files/archive';
+
+        $folders = [getenv('HIERARCHY_TESTS_BASEPATH').'/files'];
+        $finder = new FoldersTemplateFinder($folders, '');
+
+        assertSame($template, $finder->find('archive', 'archive'));
+    }
 }

--- a/tests/src/Unit/Finder/SubfolderTemplateFinderTest.php
+++ b/tests/src/Unit/Finder/SubfolderTemplateFinderTest.php
@@ -54,4 +54,16 @@ final class SubfolderTemplateFinderTest extends TestCase
 
         assertSame($template, $finder->findFirst(['page-foo', 'another', 'index'], 'page'));
     }
+
+    public function testFindSeveralExtensions()
+    {
+        $twigTemplate     = getenv('HIERARCHY_TESTS_BASEPATH').'/files/singular.twig';
+        $phpTemplate      = getenv('HIERARCHY_TESTS_BASEPATH').'/files/singular.php';
+        $fallbackTemplate = getenv('HIERARCHY_TESTS_BASEPATH').'/files/single.php';
+        $twigFinder = new SubfolderTemplateFinder('files', ['twig', 'php']);
+        $phpFinder  = new SubfolderTemplateFinder('files', ['php', 'twig']);
+        assertSame($twigTemplate, $twigFinder->find('singular', 'singular'));
+        assertSame($phpTemplate, $phpFinder->find('singular', 'singular'));
+        assertSame($fallbackTemplate, $twigFinder->find('single', 'single'));
+    }
 }


### PR DESCRIPTION
Allow FoldersTemplateFinder and SubfolderTemplateFinder to receive either a string or an array as 2nd argument ($extension).

If more than 1 extension was passed in form of an array, they will iterate over each of the extensions to find the first one that matches.
Includes unit tests.

Replaces #3
Resolves #2
