### PR TITLE
Add ExtensionParserTrait

### DIFF
--- a/src/Finder/ExtensionParserTrait.php
+++ b/src/Finder/ExtensionParserTrait.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * This file is part of the Hierarchy package.
+ *
+ * (c) Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Brain\Hierarchy\Finder;
+
+trait ExtensionParserTrait {
+
+	/**
+	 * Pattern used to trim the individual extensions.
+	 * Default trims dots, spaces, tabs and new lines.
+	 *
+	 * @var string
+	 */
+	private $_trimPattern = ". \t\n\r\0\x0B";
+
+	/**
+	 * Parse a string or an array of strings into an array of extensions.
+	 *
+	 * @param string|string[] $extensions
+	 * @return string[]
+	 */
+	private function parseExtensions($extensions)
+	{
+		$parsed = [];
+		$extensions = is_string($extensions) ? explode('|', $extensions) : (array) $extensions;
+		foreach ($extensions as $extension) {
+			if (is_string($extension)) {
+				$extension = strtolower(trim($extension, $this->_trimPattern));
+				in_array($extension, $parsed, true) or $parsed[] = $extension;
+			}
+		}
+
+		return $parsed;
+	}
+}

--- a/src/Finder/FoldersTemplateFinder.php
+++ b/src/Finder/FoldersTemplateFinder.php
@@ -25,6 +25,7 @@ use ArrayIterator;
 final class FoldersTemplateFinder implements TemplateFinderInterface
 {
     use FindFirstTemplateTrait;
+    use ExtensionParserTrait;
 
     /**
      * @var \ArrayIterator
@@ -68,23 +69,5 @@ final class FoldersTemplateFinder implements TemplateFinderInterface
         }
 
         return '';
-    }
-
-    /**
-     * @param string|string[] $extensions
-     * @return string[]
-     */
-    private function parseExtensions($extensions)
-    {
-        $parsed = [];
-        $extensions = is_string($extensions) ? explode('|', $extensions) : (array) $extensions;
-        foreach ($extensions as $extension) {
-            if (is_string($extension)) {
-                $extension = strtolower(trim($extension, ". \t\n\r\0\x0B"));
-                in_array($extension, $parsed, true) or $parsed[] = $extension;
-            }
-        }
-
-        return $parsed;
     }
 }

--- a/src/Loader/FileExtensionPredicate.php
+++ b/src/Loader/FileExtensionPredicate.php
@@ -10,6 +10,8 @@
 
 namespace Brain\Hierarchy\Loader;
 
+use Brain\Hierarchy\Finder\ExtensionParserTrait;
+
 /**
  * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
  * @license http://opensource.org/licenses/MIT MIT
@@ -17,6 +19,8 @@ namespace Brain\Hierarchy\Loader;
  */
 class FileExtensionPredicate
 {
+    use ExtensionParserTrait;
+
     /**
      * @var string[]
      */
@@ -27,10 +31,7 @@ class FileExtensionPredicate
      */
     public function __construct($extension)
     {
-        $extensions = is_string($extension) ? explode('|', $extension) : (array) $extension;
-        foreach ($extensions as $extension) {
-            is_string($extension) and $this->extension[] = strtolower(trim($extension, ". \t\n\r\0\x0B"));
-        }
+        $this->extension = $this->parseExtensions($extension);
     }
 
     /**

--- a/tests/src/Unit/Finder/ExtensionParserTraitTest.php
+++ b/tests/src/Unit/Finder/ExtensionParserTraitTest.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * This file is part of the Hierarchy package.
+ *
+ * (c) Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Brain\Hierarchy\Tests\Unit\Finder;
+
+use Brain\Hierarchy\Finder\ExtensionParserTrait;
+use Brain\Hierarchy\Tests\TestCase;
+
+
+/**
+ * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @package Hierarchy
+ */
+class FileExtensionPredicateTest extends TestCase
+{
+	use ExtensionParserTrait;
+
+	/**
+	 * @dataProvider extensionDataProvider
+	 */
+	public function testExtensionParser($input, $output)
+	{
+		assertEquals($output, $extension = $this->parseExtensions($input));
+	}
+
+	public function extensionDataProvider() {
+		return [
+			// $input, $output
+		    [ 'php', [ 'php' ] ],
+			[ "\0\n\t .PhP \0\n\t", [ 'php' ] ],
+		    [ 'twig|php|html', [ 'twig', 'php', 'html' ] ],
+			[ "\nTWIG | php\t | .Html", [ 'twig', 'php', 'html' ] ],
+		];
+	}
+}


### PR DESCRIPTION
To make the code more DRY, I added a trait to parse extensions. This trait is then used in `FoldersTemplateFinder` as well as in `FileExtensionPredicate`.

I also added the corresponding unit test.
