### PR TITLE
Fix issue on page preview

### DIFF
--- a/src/Branch/BranchPage.php
+++ b/src/Branch/BranchPage.php
@@ -40,10 +40,12 @@ final class BranchPage implements BranchInterface
         /** @var \WP_Post $post */
         $post = $query->get_queried_object();
 
-        $post instanceof \WP_Post or $post = new \WP_Post((object) ['ID' => 0, 'post_title' => '']);
-        $pagename = !$query->get('pagename') && $query->is_preview
-            ? sanitize_title($post->post_title)
-            : $query->get('pagename');
+        $post instanceof \WP_Post or $post = new \WP_Post((object) ['ID' => 0]);
+        $pagename = $query->get('pagename');
+
+        if (!$pagename && $query->is_preview() && $query->get('page_id')) {
+            $pagename = sanitize_title($post->post_title);
+        }
 
         if (empty($post->post_name) && empty($pagename)) {
             return ['page'];

--- a/src/Branch/BranchPage.php
+++ b/src/Branch/BranchPage.php
@@ -40,8 +40,10 @@ final class BranchPage implements BranchInterface
         /** @var \WP_Post $post */
         $post = $query->get_queried_object();
 
-        $post instanceof \WP_Post or $post = new \WP_Post((object) ['ID' => 0]);
-        $pagename = $query->get('pagename');
+        $post instanceof \WP_Post or $post = new \WP_Post((object) ['ID' => 0, 'post_title' => '']);
+        $pagename = !$query->get('pagename') && $query->is_preview
+            ? sanitize_title($post->post_title)
+            : $query->get('pagename');
 
         if (empty($post->post_name) && empty($pagename)) {
             return ['page'];


### PR DESCRIPTION
Fixed an issue where the wrong page hierarchy would be returned when in preview mode of a newly created page.

This was a problem when you would create a new page, selected a custom template and previewed it. The hierarchy would still be Page/Singular due to `$post->post_name` not being set.