### PR TITLE
Fix templateForType not matching $stored

### DIFF
--- a/src/PostTemplates.php
+++ b/src/PostTemplates.php
@@ -66,7 +66,8 @@ class PostTemplates
         $templates = (array)wp_get_theme()->get_page_templates(null, $postType);
         foreach ($templates as $template => $header) {
             if ($template && is_string($template)) {
-                $this->templates[$postType][] = wp_normalize_path($template);
+                $sanitized = filter_var($template, FILTER_SANITIZE_URL);
+                $this->templates[$postType][] = wp_normalize_path($sanitized);
             }
         }
 


### PR DESCRIPTION
Upon further testing with custom template names I found an issue where which would not match despite my previous comment in https://github.com/Brain-WP/Hierarchy/issues/15#issuecomment-425546657

Tested with `template-åäö.php`