### PR TITLE
Enable PHP 5.5 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
 
 matrix:
-  allow_failures:
-    - php: hhvm
+  include:
+    - php: 5.5
+      dist: trusty
 
 before_script:
   - composer install


### PR DESCRIPTION
and HHVM is a thing of the past