### PR TITLE
Add `is_favicon` to the `mainQueryTemplateAllowed` conditions

### DIFF
--- a/src/QueryTemplate.php
+++ b/src/QueryTemplate.php
@@ -65,6 +65,7 @@ final class QueryTemplate implements QueryTemplateInterface
                 || !apply_filters('exit_on_http_head', true)
             )
             && !is_robots()
+            && !is_favicon()
             && !is_feed()
             && !is_trackback()
             && !is_embed();


### PR DESCRIPTION
See https://github.com/WordPress/WordPress/blob/fefd1930c5999e614c691a40a2ac050df273199d/wp-includes/template-loader.php#L39