### PR TITLE
Fix findTemplate when 404

### DIFF
--- a/src/QueryTemplate.php
+++ b/src/QueryTemplate.php
@@ -84,7 +84,7 @@ class QueryTemplate
         $found = '';
         while ($types && !$found) {
             $type = array_shift($types);
-            $found = $this->finder->findFirst($leaves[$type], $type);
+            $found = $this->finder->findFirst($leaves[$type], (string) $type);
             $filters and $found = $this->applyFilter("{$type}_template", $found, $query);
         }
 

--- a/tests/src/Unit/QueryTemplateTest.php
+++ b/tests/src/Unit/QueryTemplateTest.php
@@ -186,6 +186,24 @@ class QueryTemplateTest extends TestCase
     /**
      * @test
      */
+    public function testFindTemplateWhen404(): void
+    {
+        $wpQuery = new \WP_Query([
+            'is_404' => true,
+        ]);
+
+        $finder = \Mockery::mock(TemplateFinder::class);
+        $finder->expects('findFirst')->andReturn('foo');
+
+        $loader = new QueryTemplate($finder);
+        $loaded = $loader->findTemplate($wpQuery);
+
+        static::assertSame('foo', $loaded);
+    }
+
+    /**
+     * @test
+     */
     public function testMainQueryTemplateAllowedTrue(): void
     {
         Functions\when('is_robots')->justReturn(false);


### PR DESCRIPTION
[`array_keys`](https://github.com/Brain-WP/Hierarchy/blob/e1303b3d5380ebd40347447a622a965a0fa1db7a/src/QueryTemplate.php#L83) automatically casts values which leads 404 to become an `int` and [`findFirst`](https://github.com/Brain-WP/Hierarchy/blob/e1303b3d5380ebd40347447a622a965a0fa1db7a/src/Finder/FindFirstTrait.php#L31) is expecting a string. 