### PR TITLE
Fix `${type}_template` filter

### DIFF
--- a/src/QueryTemplate.php
+++ b/src/QueryTemplate.php
@@ -86,7 +86,12 @@ class QueryTemplate
             $type = array_shift($types);
             $templates = $leaves[$type];
             $found = $this->finder->findFirst($templates, (string) $type);
-            $filters and $found = $this->applyFilter("{$type}_template", $found, $query, [$type, $templates]);
+            $filters and $found = $this->applyFilter(
+                "{$type}_template",
+                $found,
+                $query,
+                [$type, $templates]
+            );
         }
 
         return $found;

--- a/tests/src/Unit/QueryTemplateTest.php
+++ b/tests/src/Unit/QueryTemplateTest.php
@@ -146,7 +146,7 @@ class QueryTemplateTest extends TestCase
 
         Filters\expectApplied('foo_template')
             ->once()
-            ->with('found!')
+            ->with(...['found!', 'foo', ['foo', 'bar']])
             ->andReturnUsing(
                 static function () use ($customQuery): string {
                     // during filter, globals `$wp_query` and `$wp_the_query` are equal to custom


### PR DESCRIPTION
This filter takes three arguments that are needed when using block templates (FSE):
- https://developer.wordpress.org/reference/hooks/type_template/
- https://github.com/WordPress/WordPress/blob/665719b9dec1a287b887f6d5b33659621794cb5b/wp-includes/block-template.php#L25

Provides those arguments to ensure filter compatibility